### PR TITLE
Fix OIDC algorithm

### DIFF
--- a/docs/POST_INSTALL_STEPS.md
+++ b/docs/POST_INSTALL_STEPS.md
@@ -275,9 +275,11 @@ MemberMatters can be configured to use your OIDC-enabled Identity provider.  You
 - OIDC_OP_AUTHORIZATION_ENDPOINT (`MM_OIDC_OP_AUTHORIZATION_ENDPOINT`)
 - OIDC_OP_TOKEN_ENDPOINT (`MM_OIDC_OP_TOKEN_ENDPOINT`)
 - OIDC_OP_USER_ENDPOINT (`MM_OIDC_OP_USER_ENDPOINT`)
+- OIDC_OP_JWKS_ENDPOINT (`MM_OIDC_OP_JWKS_ENDPOINT`)
 
 Optionally set the following to override default functionality:
 - MM_OIDC_CREATE_USER: Default value is `True`.  Set to `False` if you prefer that your MemberMatters admin create or import new users manually before the account can authenticate using OIDC
 - MM_OIDC_TOKEN_EXPIRY: Default value is 3600.  Override to extend or shorten the validity window of the user's authentication token (time in seconds).
+- MM_OIDC_RP_SIGN_ALGO: Default value is "RS256". Override to use another sign algorithm.
 
 Finally, enable the `ENABLE_OIDC_RP` toggle in the Django constance config panel.  Now, when presented with the login screen a user would click "Login with OAuth" to authenticate via OIDC.

--- a/memberportal/membermatters/settings.py
+++ b/memberportal/membermatters/settings.py
@@ -44,7 +44,7 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get(
     "MM_OIDC_OP_AUTHORIZATION_ENDPOINT", None
 )
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("MM_OIDC_OP_TOKEN_ENDPOINT", None)
-OIDC_OP_USER_ENDPOINT = os.environ.get("MM_OIDC_OP_USER_ENDPOINT", None
+OIDC_OP_USER_ENDPOINT = os.environ.get("MM_OIDC_OP_USER_ENDPOINT", None)
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("MM_OIDC_OP_JWKS_ENDPOINT", None)
 # Set the following to False if you want your MM admin to create a user & profile (matches on email address) instead of creating from the Idp
 OIDC_CREATE_USER = os.environ.get("MM_OIDC_CREATE_USER", True)

--- a/memberportal/membermatters/settings.py
+++ b/memberportal/membermatters/settings.py
@@ -37,6 +37,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 ### mozilla-django-oidc config
 # get these from your IDP
+OIDC_RP_SIGN_ALGO = os.environ.get("MM_OIDC_SIGN_ALGO", "RS256")
 OIDC_RP_CLIENT_ID = os.environ.get("MM_OIDC_CLIENT_ID", None)
 OIDC_RP_CLIENT_SECRET = os.environ.get("MM_OIDC_CLIENT_SECRET", None)
 OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get(

--- a/memberportal/membermatters/settings.py
+++ b/memberportal/membermatters/settings.py
@@ -44,7 +44,8 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get(
     "MM_OIDC_OP_AUTHORIZATION_ENDPOINT", None
 )
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("MM_OIDC_OP_TOKEN_ENDPOINT", None)
-OIDC_OP_USER_ENDPOINT = os.environ.get("MM_OIDC_OP_USER_ENDPOINT", None)
+OIDC_OP_USER_ENDPOINT = os.environ.get("MM_OIDC_OP_USER_ENDPOINT", None
+OIDC_OP_JWKS_ENDPOINT = os.environ.get("MM_OIDC_OP_JWKS_ENDPOINT", None)
 # Set the following to False if you want your MM admin to create a user & profile (matches on email address) instead of creating from the Idp
 OIDC_CREATE_USER = os.environ.get("MM_OIDC_CREATE_USER", True)
 # Extend token validity window, default is 15 minutes


### PR DESCRIPTION
Mozilla OIDC defaults to HS256 algorithm but OIDC standard is RS256 so added an environment variable to set this that has RS256 as default